### PR TITLE
wording adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 						<div class="section_wrapper">
 							<div class="column mcb-column">
 								<p class="big">
-							    Join us, along with global EdTech leaders, between Tuesday, March 28th and Friday, March 31st, 2023 at the Massachusetts Institute of Technology in Cambridge, Massachusetts, to learn about innovative uses of the Open edX Platform, within a variety of business and higher education use cases, and discover the latest advancements in instructional design, course constellation and methods for operating &amp; extending the Open edX platform </p>
+							    Join us, along with global EdTech leaders, from Tuesday, March 28th to Friday, March 31st, 2023 at the Massachusetts Institute of Technology in Cambridge, Massachusetts. Learn about innovative uses of the Open edX Platform, within a variety of business and higher education use cases, and discover the latest advancements in instructional design, course constellation and methods for operating &amp; extending the Open edX platform</p>
 								<!-- #Content
 								<p class="big">
 							    &nbsp; </p>
@@ -214,7 +214,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 								<div class="column column_column ">
 									<div class="column_attr clearfix align_center">
 										<p class="big">Would you like to speak at Open edX 2023?&nbsp;</p>
-										<p class="big">Our Call for Proposals is open between now and January 23rd, 2023. To learn about the types of presentations we are seeking and how you can submit a presentation proposal:</p>
+										<p class="big">Our Call for Proposals is now open, and will close on January 23, 2023. To learn about the types of presentations we are seeking and how you can submit a presentation proposal:</p>
 										<p>
 											<a class="button button_size_4 button_js kill_the_icon" href="https://sessionize.com/2023-open-edx-conference" target="_blank">
 												<span class="button_label">Propose a Talk</span>
@@ -597,7 +597,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 										<p>Free Wi-Fi will be available at the conference site. Access information will be printed in the program that you will get when you check in on the first day.</p>
 
 										<p><b>Q: What about transportation during the conference?</b></p>
-										<p>All conference events will be held at the MIT campus, which is fully accessible, and the reception will be at a restaurant that is a 10-minute walk from campus. If you have a mobility issue that prevents the walk, please include this on your registration form, and we will arrange transportation.</p>
+										<p>All conference events will be held at the MIT campus, which is fully accessible, and the reception will be at the MIT Museum that is a 10-minute walk from campus. If you have a mobility issue that prevents the walk, please include this on your registration form, and we will arrange transportation.</p>
 										<p><strong>Note:</strong> You will need to provide your own transportation from your accommodation to the conference site and back. There are public transportation options and Uber is widely used in Cambridge. We will post transportation options on our <a href="https://con.openedx.org/">website </a>in the coming weeks.</p>
 
 									    <!-- #Hotels


### PR DESCRIPTION
First paragraph
Line 1: “from" instead of “between”
Line 2: Period after Massachusetts. Then take out the “to” and start the sentence with “Learn".

Second paragraph regarding Calls for Proposals
Line 1: instead of “is open between now and”, say “is now open, and will close on January 23, 2023.

In the FAQ under Event Details, question 4 about transportation:
Replace “a restaurant” with “ the MIT Museum"
